### PR TITLE
Address CVE-2018-18074

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ docutils==0.12            # via botocore
 futures==3.0.5            # via s3transfer
 jmespath==0.9.0           # via boto3, botocore
 python-dateutil==2.5.3    # via botocore
-requests==2.11.1
+requests==2.21.0
 s3transfer==0.1.12        # via boto3
 six==1.10.0               # via python-dateutil


### PR DESCRIPTION
This project is currently vulnerable to [CVE-2018-18074](https://app.snyk.io/org/noredink/project/2744ce7d-fe4a-4e05-beda-3bfb98206b71/), through the dependency on the `requests` library. Upgrading to a version above 2.20 should address the issue. This is a naive attempt at upgrading straight to the latest version, 2.21.0.

I'm not a Pythonista so I'm not sure if this will work. Worth a shot though!

**EDIT**: seems CI is green! Asking @ento for a review, since you are the sole contributor to this repo!