### PR TITLE
Upgrade urrlib3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,17 @@ pip install -r requirements.txt
 pip install -r dev-requirements.txt
 pytest tests.py
 ```
+
+## Upgrading a dependency
+
+If you have Nix, you can load a shell with the necessary dependencies like this:
+
+```
+nix-shell -p python37Packages.pip-tools
+```
+
+Once in the shell, run:
+
+```
+pip-compile --upgrade-package my-package
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,11 +9,10 @@ botocore==1.8.11
 certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
 docutils==0.14            # via botocore
-futures==3.2.0            # via s3transfer
 idna==2.8                 # via requests
 jmespath==0.9.3           # via boto3, botocore
 python-dateutil==2.7.5    # via botocore
 requests==2.21.0
 s3transfer==0.1.13        # via boto3
 six==1.12.0               # via python-dateutil
-urllib3==1.24.1           # via requests
+urllib3==1.24.3


### PR DESCRIPTION
Part of Puffin security guardian duty.

This upgrade addresses a vulnerability with the previous version of the library:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11324